### PR TITLE
Phase 2: Metric instruments and frame metrics aggregator

### DIFF
--- a/src/avatar_otel/metrics/aggregator.py
+++ b/src/avatar_otel/metrics/aggregator.py
@@ -1,0 +1,123 @@
+"""FrameMetricsAggregator — ring buffer + flush thread.
+
+Solves the 30fps overhead problem: OTel calls never happen on the hot path.
+Hot path writes to a lock-protected C array (~200ns). A background daemon thread
+flushes aggregated samples to OTel histograms at a configurable interval.
+"""
+
+from __future__ import annotations
+
+import array
+import threading
+import time
+from dataclasses import dataclass, field
+
+from avatar_otel.metrics.instruments import MetricInstruments
+
+
+@dataclass
+class _RingBuffer:
+    """Fixed-size ring buffer backed by array.array('d')."""
+
+    capacity: int
+    _buf: array.array = field(init=False)
+    _write_idx: int = field(init=False, default=0)
+    _count: int = field(init=False, default=0)
+
+    def __post_init__(self) -> None:
+        self._buf = array.array("d", [0.0] * self.capacity)
+
+    def write(self, value: float) -> None:
+        idx = self._write_idx & (self.capacity - 1)
+        self._buf[idx] = value
+        self._write_idx += 1
+        if self._count < self.capacity:
+            self._count += 1
+
+    def drain(self) -> list[float]:
+        """Return all samples and reset the buffer."""
+        if self._count == 0:
+            return []
+        if self._count < self.capacity:
+            result = list(self._buf[: self._count])
+        else:
+            start = self._write_idx & (self.capacity - 1)
+            result = list(self._buf[start:]) + list(self._buf[:start])
+        self._write_idx = 0
+        self._count = 0
+        return result
+
+
+class FrameMetricsAggregator:
+    """Aggregates per-frame metrics in ring buffers, flushing to OTel periodically.
+
+    Usage on the hot path (render thread):
+        aggregator.record(forward_pass_ms=11.2, render_ms=3.1)
+
+    The flush thread (daemon) exports aggregated samples to OTel histograms.
+    """
+
+    # Metric names that map to ring buffers and their OTel instrument attrs
+    METRIC_KEYS = (
+        "forward_pass_ms",
+        "render_ms",
+        "encode_ms",
+        "audio_ms",
+    )
+
+    def __init__(
+        self,
+        instruments: MetricInstruments,
+        buffer_size: int = 512,
+        flush_interval_ms: int = 1_000,
+    ) -> None:
+        self._instruments = instruments
+        self._flush_interval_s = flush_interval_ms / 1000.0
+        self._lock = threading.Lock()
+        self._stop_event = threading.Event()
+
+        self._buffers: dict[str, _RingBuffer] = {
+            key: _RingBuffer(capacity=buffer_size) for key in self.METRIC_KEYS
+        }
+
+        self._thread = threading.Thread(
+            target=self._flush_loop, daemon=True, name="avatar-otel-flush"
+        )
+
+    def start(self) -> None:
+        self._thread.start()
+
+    def stop(self) -> None:
+        self._stop_event.set()
+        self._thread.join(timeout=5.0)
+        self._flush()
+
+    def record(self, **kwargs: float) -> None:
+        """Record metric values into ring buffers. ~200ns per call."""
+        with self._lock:
+            for key, value in kwargs.items():
+                buf = self._buffers.get(key)
+                if buf is not None:
+                    buf.write(value)
+
+    def _flush_loop(self) -> None:
+        while not self._stop_event.wait(timeout=self._flush_interval_s):
+            self._flush()
+
+    def _flush(self) -> None:
+        with self._lock:
+            snapshots = {key: buf.drain() for key, buf in self._buffers.items()}
+
+        instrument_map = {
+            "forward_pass_ms": self._instruments.forward_pass_duration,
+            "render_ms": self._instruments.render_frame_duration,
+            "encode_ms": self._instruments.encode_frame_duration,
+            "audio_ms": self._instruments.audio_chunk_duration,
+        }
+
+        for key, samples in snapshots.items():
+            histogram = instrument_map.get(key)
+            if histogram is None:
+                continue
+            for value in samples:
+                histogram.record(value)

--- a/src/avatar_otel/metrics/instruments.py
+++ b/src/avatar_otel/metrics/instruments.py
@@ -1,0 +1,67 @@
+"""Pre-allocated OTel metric instruments.
+
+All instruments are created once at init() time — never inside loops.
+"""
+
+from __future__ import annotations
+
+from opentelemetry.metrics import Histogram, Counter, Meter
+
+
+class MetricInstruments:
+    """Holds all pre-allocated OTel metric instruments."""
+
+    def __init__(self, meter: Meter) -> None:
+        # ── Histograms ────────────────────────────────────────────────────
+        self.forward_pass_duration: Histogram = meter.create_histogram(
+            name="rt_video.inference.forward_pass.duration",
+            description="Duration of model forward pass",
+            unit="ms",
+        )
+        self.render_frame_duration: Histogram = meter.create_histogram(
+            name="rt_video.render.frame.duration",
+            description="Duration of frame rendering",
+            unit="ms",
+        )
+        self.encode_frame_duration: Histogram = meter.create_histogram(
+            name="rt_video.encode.frame.duration",
+            description="Duration of frame encoding",
+            unit="ms",
+        )
+        self.audio_chunk_duration: Histogram = meter.create_histogram(
+            name="rt_video.audio.chunk.duration",
+            description="Duration of audio chunk processing",
+            unit="ms",
+        )
+        self.av_sync_drift: Histogram = meter.create_histogram(
+            name="rt_video.av_sync.drift",
+            description="Audio-video sync drift (positive = video lags audio)",
+            unit="ms",
+        )
+        self.av_sync_jitter: Histogram = meter.create_histogram(
+            name="rt_video.av_sync.jitter",
+            description="Audio-video sync jitter (MAD of drift)",
+            unit="ms",
+        )
+        self.pipeline_stage_duration: Histogram = meter.create_histogram(
+            name="rt_video.pipeline.stage.duration",
+            description="Duration of a pipeline stage",
+            unit="ms",
+        )
+
+        # ── Counters ─────────────────────────────────────────────────────
+        self.frames_processed: Counter = meter.create_counter(
+            name="rt_video.frames.processed",
+            description="Total frames processed",
+            unit="frames",
+        )
+        self.frames_dropped: Counter = meter.create_counter(
+            name="rt_video.frames.dropped",
+            description="Total frames dropped",
+            unit="frames",
+        )
+        self.av_sync_unmatched: Counter = meter.create_counter(
+            name="rt_video.av_sync.unmatched_chunks",
+            description="Audio chunks that expired without a matching frame",
+            unit="chunks",
+        )

--- a/tests/test_aggregator.py
+++ b/tests/test_aggregator.py
@@ -1,0 +1,98 @@
+"""Tests for FrameMetricsAggregator and ring buffer."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from avatar_otel.metrics.aggregator import FrameMetricsAggregator, _RingBuffer
+
+
+class TestRingBuffer:
+    def test_write_and_drain(self):
+        buf = _RingBuffer(capacity=4)
+        buf.write(1.0)
+        buf.write(2.0)
+        buf.write(3.0)
+        assert buf.drain() == [1.0, 2.0, 3.0]
+
+    def test_drain_empty(self):
+        buf = _RingBuffer(capacity=4)
+        assert buf.drain() == []
+
+    def test_wrap_around(self):
+        buf = _RingBuffer(capacity=4)
+        for i in range(6):
+            buf.write(float(i))
+        # Should contain last 4 values: 2.0, 3.0, 4.0, 5.0
+        result = buf.drain()
+        assert result == [2.0, 3.0, 4.0, 5.0]
+
+    def test_drain_resets(self):
+        buf = _RingBuffer(capacity=4)
+        buf.write(1.0)
+        buf.drain()
+        assert buf.drain() == []
+
+    def test_exact_capacity(self):
+        buf = _RingBuffer(capacity=4)
+        for i in range(4):
+            buf.write(float(i))
+        assert buf.drain() == [0.0, 1.0, 2.0, 3.0]
+
+
+class TestFrameMetricsAggregator:
+    @pytest.fixture
+    def mock_instruments(self):
+        instruments = MagicMock()
+        instruments.forward_pass_duration = MagicMock()
+        instruments.render_frame_duration = MagicMock()
+        instruments.encode_frame_duration = MagicMock()
+        instruments.audio_chunk_duration = MagicMock()
+        return instruments
+
+    def test_record_and_flush(self, mock_instruments):
+        agg = FrameMetricsAggregator(
+            instruments=mock_instruments, buffer_size=16, flush_interval_ms=10_000
+        )
+        agg.record(forward_pass_ms=11.2, render_ms=3.1)
+        agg.record(forward_pass_ms=12.0)
+
+        # Manual flush
+        agg._flush()
+
+        assert mock_instruments.forward_pass_duration.record.call_count == 2
+        assert mock_instruments.render_frame_duration.record.call_count == 1
+
+    def test_unknown_keys_ignored(self, mock_instruments):
+        agg = FrameMetricsAggregator(
+            instruments=mock_instruments, buffer_size=16, flush_interval_ms=10_000
+        )
+        agg.record(forward_pass_ms=1.0, unknown_metric=99.0)
+        agg._flush()
+
+        assert mock_instruments.forward_pass_duration.record.call_count == 1
+
+    def test_start_stop(self, mock_instruments):
+        agg = FrameMetricsAggregator(
+            instruments=mock_instruments, buffer_size=16, flush_interval_ms=50
+        )
+        agg.start()
+        agg.record(forward_pass_ms=10.0)
+        agg.stop()
+
+        assert mock_instruments.forward_pass_duration.record.call_count >= 1
+
+    def test_ring_buffer_overflow(self, mock_instruments):
+        agg = FrameMetricsAggregator(
+            instruments=mock_instruments, buffer_size=4, flush_interval_ms=10_000
+        )
+        for i in range(8):
+            agg.record(forward_pass_ms=float(i))
+        agg._flush()
+
+        # Only last 4 samples should be flushed
+        assert mock_instruments.forward_pass_duration.record.call_count == 4
+        calls = [c.args[0] for c in mock_instruments.forward_pass_duration.record.call_args_list]
+        assert calls == [4.0, 5.0, 6.0, 7.0]


### PR DESCRIPTION
## Summary
- Pre-allocated OTel metric instruments (histograms for durations, counters for frames)
- `FrameMetricsAggregator` with ring buffer (~200ns hot path) + daemon flush thread
- Ring buffer uses `array.array('d')` with bitmask indexing (power-of-2 capacity)

## Test plan
- [x] Ring buffer write/drain correctness
- [x] Wrap-around preserves latest N samples
- [x] Aggregator records and flushes to correct OTel instruments
- [x] Unknown metric keys silently ignored
- [x] Start/stop lifecycle works cleanly
- [x] 9/9 tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)