### PR TITLE
Phase 3: Adaptive sampler and pipeline stage tracing

### DIFF
--- a/src/avatar_otel/tracing/pipeline.py
+++ b/src/avatar_otel/tracing/pipeline.py
@@ -1,0 +1,211 @@
+"""Pipeline stage tracing — @pipeline_stage decorator and stage() context manager.
+
+Two interfaces over one implementation. Yields StageContext (not raw OTel span)
+for a stable public API. Yields _NoOpStageContext when the sampler skips.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import functools
+import inspect
+import time
+from collections.abc import AsyncGenerator, Generator
+from contextlib import asynccontextmanager, contextmanager
+from dataclasses import dataclass, field
+from typing import Any, Callable, ParamSpec, TypeVar
+
+from opentelemetry import trace
+from opentelemetry.trace import StatusCode
+
+from avatar_otel.conventions.attributes import PipelineAttributes
+from avatar_otel.tracing.sampler import AdaptiveSampler
+
+P = ParamSpec("P")
+R = TypeVar("R")
+
+
+@dataclass
+class StageContext:
+    """Public interface for an active pipeline stage span."""
+
+    _span: trace.Span
+    _attributes: dict[str, Any] = field(default_factory=dict)
+
+    def set_attribute(self, key: str, value: Any) -> None:
+        self._span.set_attribute(key, value)
+
+    def record(self, key: str, value: Any) -> None:
+        self._span.set_attribute(key, value)
+
+    @property
+    def span(self) -> trace.Span:
+        return self._span
+
+
+@dataclass
+class _NoOpStageContext:
+    """No-op context returned when the sampler skips this stage."""
+
+    def set_attribute(self, key: str, value: Any) -> None:
+        pass
+
+    def record(self, key: str, value: Any) -> None:
+        pass
+
+    @property
+    def span(self) -> None:
+        return None
+
+
+def pipeline_stage(
+    stage_name: str,
+    *,
+    always_trace: bool = False,
+    tracer: trace.Tracer | None = None,
+    sampler: AdaptiveSampler | None = None,
+) -> Callable:
+    """Decorator to instrument a pipeline stage function.
+
+    Detects async at decoration time (not per-call) for zero runtime branch.
+    """
+
+    def decorator(fn: Callable[P, R]) -> Callable[P, R]:
+        is_async = inspect.iscoroutinefunction(fn)
+
+        if is_async:
+
+            @functools.wraps(fn)
+            async def async_wrapper(*args: P.args, **kwargs: P.kwargs) -> R:
+                _sampler = sampler or _get_default_sampler()
+                _tracer = tracer or _get_default_tracer()
+
+                if not _sampler.should_sample(stage_name, always_trace=always_trace):
+                    return await fn(*args, **kwargs)
+
+                with _tracer.start_as_current_span(f"rt_video.{stage_name}") as span:
+                    span.set_attribute(PipelineAttributes.STAGE_NAME, stage_name)
+                    start = time.perf_counter()
+                    try:
+                        result = await fn(*args, **kwargs)
+                        return result
+                    except Exception as exc:
+                        span.set_status(StatusCode.ERROR, str(exc))
+                        span.record_exception(exc)
+                        raise
+                    finally:
+                        elapsed_ms = (time.perf_counter() - start) * 1000
+                        span.set_attribute(PipelineAttributes.STAGE_DURATION_MS, elapsed_ms)
+
+            return async_wrapper  # type: ignore[return-value]
+        else:
+
+            @functools.wraps(fn)
+            def sync_wrapper(*args: P.args, **kwargs: P.kwargs) -> R:
+                _sampler = sampler or _get_default_sampler()
+                _tracer = tracer or _get_default_tracer()
+
+                if not _sampler.should_sample(stage_name, always_trace=always_trace):
+                    return fn(*args, **kwargs)
+
+                with _tracer.start_as_current_span(f"rt_video.{stage_name}") as span:
+                    span.set_attribute(PipelineAttributes.STAGE_NAME, stage_name)
+                    start = time.perf_counter()
+                    try:
+                        result = fn(*args, **kwargs)
+                        return result
+                    except Exception as exc:
+                        span.set_status(StatusCode.ERROR, str(exc))
+                        span.record_exception(exc)
+                        raise
+                    finally:
+                        elapsed_ms = (time.perf_counter() - start) * 1000
+                        span.set_attribute(PipelineAttributes.STAGE_DURATION_MS, elapsed_ms)
+
+            return sync_wrapper  # type: ignore[return-value]
+
+    return decorator
+
+
+@contextmanager
+def stage(
+    stage_name: str,
+    *,
+    tracer: trace.Tracer | None = None,
+    sampler: AdaptiveSampler | None = None,
+    always_trace: bool = False,
+    **attrs: Any,
+) -> Generator[StageContext | _NoOpStageContext, None, None]:
+    """Synchronous context manager for pipeline stage tracing."""
+    _sampler = sampler or _get_default_sampler()
+    _tracer = tracer or _get_default_tracer()
+
+    if not _sampler.should_sample(stage_name, always_trace=always_trace):
+        yield _NoOpStageContext()
+        return
+
+    with _tracer.start_as_current_span(f"rt_video.{stage_name}") as span:
+        span.set_attribute(PipelineAttributes.STAGE_NAME, stage_name)
+        for key, value in attrs.items():
+            span.set_attribute(key, value)
+        ctx = StageContext(_span=span)
+        start = time.perf_counter()
+        try:
+            yield ctx
+        except Exception as exc:
+            span.set_status(StatusCode.ERROR, str(exc))
+            span.record_exception(exc)
+            raise
+        finally:
+            elapsed_ms = (time.perf_counter() - start) * 1000
+            span.set_attribute(PipelineAttributes.STAGE_DURATION_MS, elapsed_ms)
+
+
+@asynccontextmanager
+async def async_stage(
+    stage_name: str,
+    *,
+    tracer: trace.Tracer | None = None,
+    sampler: AdaptiveSampler | None = None,
+    always_trace: bool = False,
+    **attrs: Any,
+) -> AsyncGenerator[StageContext | _NoOpStageContext, None]:
+    """Async context manager for pipeline stage tracing."""
+    _sampler = sampler or _get_default_sampler()
+    _tracer = tracer or _get_default_tracer()
+
+    if not _sampler.should_sample(stage_name, always_trace=always_trace):
+        yield _NoOpStageContext()
+        return
+
+    with _tracer.start_as_current_span(f"rt_video.{stage_name}") as span:
+        span.set_attribute(PipelineAttributes.STAGE_NAME, stage_name)
+        for key, value in attrs.items():
+            span.set_attribute(key, value)
+        ctx = StageContext(_span=span)
+        start = time.perf_counter()
+        try:
+            yield ctx
+        except Exception as exc:
+            span.set_status(StatusCode.ERROR, str(exc))
+            span.record_exception(exc)
+            raise
+        finally:
+            elapsed_ms = (time.perf_counter() - start) * 1000
+            span.set_attribute(PipelineAttributes.STAGE_DURATION_MS, elapsed_ms)
+
+
+def _get_default_tracer() -> trace.Tracer:
+    from avatar_otel import _registry
+
+    if _registry._tracer is not None:
+        return _registry._tracer
+    return trace.get_tracer("avatar-otel")
+
+
+def _get_default_sampler() -> AdaptiveSampler:
+    from avatar_otel import _registry
+
+    if hasattr(_registry, "_sampler") and _registry._sampler is not None:
+        return _registry._sampler
+    return AdaptiveSampler()

--- a/src/avatar_otel/tracing/sampler.py
+++ b/src/avatar_otel/tracing/sampler.py
@@ -1,0 +1,57 @@
+"""AdaptiveSampler — time-window + anomaly-based sampling.
+
+Three-tier decision (evaluated in order):
+1. FORCE   -> always_trace=True on the decorator -> always create span
+2. ANOMALY -> elapsed_ms > anomaly_threshold_ms -> always create span
+3. WINDOW  -> one span per stage per window_s -> rate limit
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+
+
+class AdaptiveSampler:
+    """Decides whether to create a span for a given pipeline stage."""
+
+    def __init__(
+        self,
+        window_s: float = 1.0,
+        anomaly_threshold_ms: float = 50.0,
+    ) -> None:
+        self._window_s = window_s
+        self._anomaly_threshold_ms = anomaly_threshold_ms
+        self._last_span_time: dict[str, float] = {}
+        self._lock = threading.Lock()
+
+    def should_sample(
+        self,
+        stage_name: str,
+        *,
+        always_trace: bool = False,
+        elapsed_ms: float | None = None,
+    ) -> bool:
+        """Decide whether to create a span.
+
+        Args:
+            stage_name: Name of the pipeline stage.
+            always_trace: If True, always sample (force tier).
+            elapsed_ms: If provided and exceeds threshold, always sample (anomaly tier).
+
+        Returns:
+            True if a span should be created.
+        """
+        if always_trace:
+            return True
+
+        if elapsed_ms is not None and elapsed_ms > self._anomaly_threshold_ms:
+            return True
+
+        now = time.monotonic()
+        with self._lock:
+            last = self._last_span_time.get(stage_name, 0.0)
+            if now - last >= self._window_s:
+                self._last_span_time[stage_name] = now
+                return True
+        return False

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -1,0 +1,156 @@
+"""Tests for pipeline stage tracing — decorator and context manager."""
+
+from __future__ import annotations
+
+import pytest
+from opentelemetry import trace
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor, SpanExporter, SpanExportResult
+
+from avatar_otel.conventions.attributes import PipelineAttributes
+from avatar_otel.tracing.pipeline import (
+    StageContext,
+    _NoOpStageContext,
+    async_stage,
+    pipeline_stage,
+    stage,
+)
+from avatar_otel.tracing.sampler import AdaptiveSampler
+
+
+class _CollectingExporter(SpanExporter):
+    """Simple in-memory span exporter for tests."""
+
+    def __init__(self):
+        self._spans = []
+
+    def export(self, spans):
+        self._spans.extend(spans)
+        return SpanExportResult.SUCCESS
+
+    def get_finished_spans(self):
+        return list(self._spans)
+
+    def shutdown(self):
+        pass
+
+
+@pytest.fixture
+def tracing():
+    exporter = _CollectingExporter()
+    provider = TracerProvider()
+    provider.add_span_processor(SimpleSpanProcessor(exporter))
+    tracer = provider.get_tracer("test")
+    return tracer, exporter, provider
+
+
+@pytest.fixture
+def always_sampler():
+    return AdaptiveSampler(window_s=0.0)
+
+
+class TestPipelineStageDecorator:
+    def test_sync_function(self, tracing, always_sampler):
+        tracer, exporter, _ = tracing
+
+        @pipeline_stage("render", tracer=tracer, sampler=always_sampler)
+        def render_frame(data: str) -> str:
+            return f"rendered:{data}"
+
+        result = render_frame("test")
+        assert result == "rendered:test"
+
+        spans = exporter.get_finished_spans()
+        assert len(spans) == 1
+        assert spans[0].name == "rt_video.render"
+        assert spans[0].attributes[PipelineAttributes.STAGE_NAME] == "render"
+        assert PipelineAttributes.STAGE_DURATION_MS in spans[0].attributes
+
+    @pytest.mark.asyncio
+    async def test_async_function(self, tracing, always_sampler):
+        tracer, exporter, _ = tracing
+
+        @pipeline_stage("ingest", tracer=tracer, sampler=always_sampler)
+        async def ingest_audio(data: bytes) -> str:
+            return f"ingested:{len(data)}"
+
+        result = await ingest_audio(b"audio")
+        assert result == "ingested:5"
+
+        spans = exporter.get_finished_spans()
+        assert len(spans) == 1
+        assert spans[0].name == "rt_video.ingest"
+
+    def test_exception_recorded(self, tracing, always_sampler):
+        tracer, exporter, _ = tracing
+
+        @pipeline_stage("broken", tracer=tracer, sampler=always_sampler)
+        def broken_stage() -> None:
+            raise ValueError("test error")
+
+        with pytest.raises(ValueError, match="test error"):
+            broken_stage()
+
+        spans = exporter.get_finished_spans()
+        assert len(spans) == 1
+        assert spans[0].status.status_code == trace.StatusCode.ERROR
+        assert any(e.name == "exception" for e in spans[0].events)
+
+    def test_sampler_skips(self, tracing):
+        tracer, exporter, _ = tracing
+        never_sampler = AdaptiveSampler(window_s=999.0)
+        never_sampler.should_sample("skip_test")
+
+        @pipeline_stage("skip_test", tracer=tracer, sampler=never_sampler)
+        def skipped() -> str:
+            return "ok"
+
+        result = skipped()
+        assert result == "ok"
+        assert len(exporter.get_finished_spans()) == 0
+
+
+class TestStageContextManager:
+    def test_sync_stage(self, tracing, always_sampler):
+        tracer, exporter, _ = tracing
+
+        with stage("encode", tracer=tracer, sampler=always_sampler) as s:
+            assert isinstance(s, StageContext)
+            s.record("bitrate_kbps", 2400)
+
+        spans = exporter.get_finished_spans()
+        assert len(spans) == 1
+        assert spans[0].attributes["bitrate_kbps"] == 2400
+
+    @pytest.mark.asyncio
+    async def test_async_stage(self, tracing, always_sampler):
+        tracer, exporter, _ = tracing
+
+        async with async_stage("decode", tracer=tracer, sampler=always_sampler) as s:
+            s.set_attribute("codec", "h264")
+
+        spans = exporter.get_finished_spans()
+        assert len(spans) == 1
+        assert spans[0].attributes["codec"] == "h264"
+
+    def test_noop_when_not_sampled(self, tracing):
+        tracer, exporter, _ = tracing
+        never_sampler = AdaptiveSampler(window_s=999.0)
+        never_sampler.should_sample("noop_test")
+
+        with stage("noop_test", tracer=tracer, sampler=never_sampler) as s:
+            assert isinstance(s, _NoOpStageContext)
+            s.record("anything", 42)
+
+        assert len(exporter.get_finished_spans()) == 0
+
+    def test_exception_in_stage(self, tracing, always_sampler):
+        tracer, exporter, _ = tracing
+
+        with pytest.raises(RuntimeError, match="boom"):
+            with stage("explode", tracer=tracer, sampler=always_sampler) as s:
+                raise RuntimeError("boom")
+
+        spans = exporter.get_finished_spans()
+        assert len(spans) == 1
+        assert spans[0].status.status_code == trace.StatusCode.ERROR

--- a/tests/test_sampler.py
+++ b/tests/test_sampler.py
@@ -1,0 +1,46 @@
+"""Tests for AdaptiveSampler."""
+
+from __future__ import annotations
+
+import time
+from unittest.mock import patch
+
+from avatar_otel.tracing.sampler import AdaptiveSampler
+
+
+class TestAdaptiveSampler:
+    def test_always_trace(self):
+        sampler = AdaptiveSampler(window_s=100.0)
+        for _ in range(10):
+            assert sampler.should_sample("render", always_trace=True)
+
+    def test_anomaly_threshold(self):
+        sampler = AdaptiveSampler(window_s=100.0, anomaly_threshold_ms=50.0)
+        # First call within window
+        sampler.should_sample("render")
+        # Anomaly should always pass
+        assert sampler.should_sample("render", elapsed_ms=60.0)
+        assert not sampler.should_sample("render", elapsed_ms=30.0)
+
+    def test_window_sampling(self):
+        sampler = AdaptiveSampler(window_s=0.1)
+        # First call should always pass
+        assert sampler.should_sample("render")
+        # Immediate second call should be rejected
+        assert not sampler.should_sample("render")
+        # After window passes, should be accepted
+        time.sleep(0.15)
+        assert sampler.should_sample("render")
+
+    def test_different_stages_independent(self):
+        sampler = AdaptiveSampler(window_s=100.0)
+        assert sampler.should_sample("render")
+        assert sampler.should_sample("encode")
+        # Both should be rejected now (within window)
+        assert not sampler.should_sample("render")
+        assert not sampler.should_sample("encode")
+
+    def test_below_anomaly_threshold_not_sampled(self):
+        sampler = AdaptiveSampler(window_s=100.0, anomaly_threshold_ms=50.0)
+        sampler.should_sample("render")
+        assert not sampler.should_sample("render", elapsed_ms=49.0)


### PR DESCRIPTION
## Summary
- `AdaptiveSampler` with three-tier decision: force, anomaly threshold, time-window
- `@pipeline_stage` decorator (async detected at decoration time, not per-call)
- `stage()` / `async_stage()` context managers yielding `StageContext` or `_NoOpStageContext`
- Exceptions recorded via `span.record_exception()` and re-raised

## Test plan
- [x] Sampler: always_trace, anomaly threshold, window-based, independent stages
- [x] Decorator: sync function, async function, exception recording, sampler skip
- [x] Context manager: sync/async, attributes, NoOp on skip, exception handling
- [x] 13/13 tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)