### PR TITLE
Phase 8: A/V sync tracker

### DIFF
--- a/src/avatar_otel/metrics/av_sync.py
+++ b/src/avatar_otel/metrics/av_sync.py
@@ -1,0 +1,110 @@
+"""AVSyncTracker — audio-video sync drift and jitter measurement.
+
+Cross-stage measurement: audio_captured(chunk_id) records the capture timestamp,
+frame_rendered(chunk_id) computes drift. Positive drift = video lags audio.
+
+Jitter is computed as Mean Absolute Deviation of a rolling window of drift values.
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+from collections import deque
+
+from avatar_otel.conventions.attributes import AVSyncAttributes
+from avatar_otel.metrics.instruments import MetricInstruments
+
+
+class AVSyncTracker:
+    """Tracks audio-video synchronization drift and jitter."""
+
+    def __init__(
+        self,
+        instruments: MetricInstruments,
+        drift_warning_ms: float = 40.0,
+        chunk_ttl_s: float = 5.0,
+        jitter_window: int = 30,
+        warning_callback: callable | None = None,
+    ) -> None:
+        self._instruments = instruments
+        self._drift_warning_ms = drift_warning_ms
+        self._chunk_ttl_s = chunk_ttl_s
+        self._jitter_window = jitter_window
+        self._warning_callback = warning_callback
+
+        self._pending: dict[int, tuple[int, int]] = {}  # {chunk_id: (capture_ns, expiry_ns)}
+        self._lock = threading.Lock()
+        self._drift_window: deque[float] = deque(maxlen=jitter_window)
+        self._last_drift_ms: float = 0.0
+
+    @property
+    def current_drift_ms(self) -> float:
+        return self._last_drift_ms
+
+    @property
+    def current_jitter_ms(self) -> float:
+        if len(self._drift_window) < 2:
+            return 0.0
+        values = list(self._drift_window)
+        mean = sum(values) / len(values)
+        return sum(abs(v - mean) for v in values) / len(values)
+
+    def audio_captured(self, chunk_id: int) -> None:
+        """Record the timestamp when an audio chunk was captured."""
+        now_ns = time.time_ns()
+        expiry_ns = now_ns + int(self._chunk_ttl_s * 1e9)
+        with self._lock:
+            self._pending[chunk_id] = (now_ns, expiry_ns)
+
+    def frame_rendered(self, chunk_id: int) -> float | None:
+        """Record the timestamp when the frame for a chunk was rendered.
+
+        Returns the drift in milliseconds, or None if no matching audio chunk.
+        """
+        now_ns = time.time_ns()
+        with self._lock:
+            entry = self._pending.pop(chunk_id, None)
+
+        if entry is None:
+            return None
+
+        capture_ns, _ = entry
+        drift_ms = (now_ns - capture_ns) / 1e6
+        self._last_drift_ms = drift_ms
+        self._drift_window.append(drift_ms)
+
+        # Record metrics
+        self._instruments.av_sync_drift.record(drift_ms)
+        jitter = self.current_jitter_ms
+        self._instruments.av_sync_jitter.record(jitter)
+
+        # Warning on excessive drift
+        if abs(drift_ms) > self._drift_warning_ms and self._warning_callback:
+            self._warning_callback(
+                f"A/V drift exceeded threshold: {drift_ms:.1f}ms",
+                **{
+                    AVSyncAttributes.DRIFT_MS: drift_ms,
+                    AVSyncAttributes.CHUNK_ID: chunk_id,
+                    AVSyncAttributes.THRESHOLD_MS: self._drift_warning_ms,
+                },
+            )
+
+        return drift_ms
+
+    def cleanup_expired(self) -> int:
+        """Remove expired pending chunks. Returns number of chunks cleaned up."""
+        now_ns = time.time_ns()
+        expired_count = 0
+        with self._lock:
+            expired = [
+                cid for cid, (_, expiry_ns) in self._pending.items() if now_ns > expiry_ns
+            ]
+            for cid in expired:
+                del self._pending[cid]
+                expired_count += 1
+
+        if expired_count > 0:
+            self._instruments.av_sync_unmatched.add(expired_count)
+
+        return expired_count

--- a/tests/test_av_sync.py
+++ b/tests/test_av_sync.py
@@ -1,0 +1,112 @@
+"""Tests for AVSyncTracker."""
+
+from __future__ import annotations
+
+import time
+from unittest.mock import MagicMock
+
+import pytest
+
+from avatar_otel.metrics.av_sync import AVSyncTracker
+
+
+@pytest.fixture
+def mock_instruments():
+    instruments = MagicMock()
+    instruments.av_sync_drift = MagicMock()
+    instruments.av_sync_jitter = MagicMock()
+    instruments.av_sync_unmatched = MagicMock()
+    return instruments
+
+
+class TestAVSyncTracker:
+    def test_basic_drift_measurement(self, mock_instruments):
+        tracker = AVSyncTracker(instruments=mock_instruments)
+        tracker.audio_captured(chunk_id=1)
+        time.sleep(0.01)  # ~10ms
+        drift = tracker.frame_rendered(chunk_id=1)
+
+        assert drift is not None
+        assert drift > 0
+        assert tracker.current_drift_ms == drift
+        mock_instruments.av_sync_drift.record.assert_called_once()
+
+    def test_unmatched_chunk_returns_none(self, mock_instruments):
+        tracker = AVSyncTracker(instruments=mock_instruments)
+        result = tracker.frame_rendered(chunk_id=999)
+        assert result is None
+
+    def test_jitter_calculation(self, mock_instruments):
+        tracker = AVSyncTracker(instruments=mock_instruments, jitter_window=5)
+        # Manually populate drift window with known values
+        tracker._drift_window.extend([10.0, 20.0, 30.0, 40.0, 50.0])
+        # Mean = 30, MAD = (20+10+0+10+20)/5 = 12
+        assert abs(tracker.current_jitter_ms - 12.0) < 0.01
+
+    def test_jitter_with_single_value(self, mock_instruments):
+        tracker = AVSyncTracker(instruments=mock_instruments)
+        tracker._drift_window.append(10.0)
+        assert tracker.current_jitter_ms == 0.0
+
+    def test_warning_callback_on_excessive_drift(self, mock_instruments):
+        callback = MagicMock()
+        tracker = AVSyncTracker(
+            instruments=mock_instruments,
+            drift_warning_ms=5.0,
+            warning_callback=callback,
+        )
+        tracker.audio_captured(chunk_id=1)
+        time.sleep(0.01)  # >5ms
+        tracker.frame_rendered(chunk_id=1)
+
+        callback.assert_called_once()
+        call_args = callback.call_args
+        assert "drift exceeded" in call_args.args[0].lower()
+
+    def test_no_warning_below_threshold(self, mock_instruments):
+        callback = MagicMock()
+        tracker = AVSyncTracker(
+            instruments=mock_instruments,
+            drift_warning_ms=1000.0,
+            warning_callback=callback,
+        )
+        tracker.audio_captured(chunk_id=1)
+        tracker.frame_rendered(chunk_id=1)  # nearly instant
+        callback.assert_not_called()
+
+    def test_cleanup_expired(self, mock_instruments):
+        tracker = AVSyncTracker(
+            instruments=mock_instruments,
+            chunk_ttl_s=0.01,  # 10ms TTL
+        )
+        tracker.audio_captured(chunk_id=1)
+        tracker.audio_captured(chunk_id=2)
+        time.sleep(0.02)  # Wait for expiry
+
+        expired = tracker.cleanup_expired()
+        assert expired == 2
+        mock_instruments.av_sync_unmatched.add.assert_called_once_with(2)
+
+    def test_cleanup_no_expiry(self, mock_instruments):
+        tracker = AVSyncTracker(
+            instruments=mock_instruments,
+            chunk_ttl_s=100.0,
+        )
+        tracker.audio_captured(chunk_id=1)
+        expired = tracker.cleanup_expired()
+        assert expired == 0
+
+    def test_multiple_chunks(self, mock_instruments):
+        tracker = AVSyncTracker(instruments=mock_instruments)
+        tracker.audio_captured(chunk_id=1)
+        tracker.audio_captured(chunk_id=2)
+        tracker.audio_captured(chunk_id=3)
+
+        d1 = tracker.frame_rendered(chunk_id=1)
+        d3 = tracker.frame_rendered(chunk_id=3)
+        d2 = tracker.frame_rendered(chunk_id=2)
+
+        assert d1 is not None
+        assert d2 is not None
+        assert d3 is not None
+        assert mock_instruments.av_sync_drift.record.call_count == 3


### PR DESCRIPTION
## Summary
- `AVSyncTracker` with `audio_captured(chunk_id)` / `frame_rendered(chunk_id)` API
- Drift computation (positive = video lags audio)
- Jitter via Mean Absolute Deviation of rolling window
- TTL-based cleanup of unmatched chunks
- Warning callback on excessive drift

## Test plan
- [x] Basic drift measurement
- [x] Unmatched chunk returns None
- [x] Jitter calculation (MAD)
- [x] Warning callback on excessive drift
- [x] TTL expiry cleanup
- [x] Multiple concurrent chunks
- [x] 9/9 tests passing, 100% coverage on av_sync.py

🤖 Generated with [Claude Code](https://claude.com/claude-code)