### PR TITLE
Add Phase 11: event loop blocking monitor

### DIFF
--- a/src/avatar_otel/instrumentation/eventloop.py
+++ b/src/avatar_otel/instrumentation/eventloop.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+import asyncio
+import logging
+import time
+
+logger = logging.getLogger("avatar_otel.eventloop")
+
+_original_handle_run = None
+_warning_callback = None
+
+def install_eventloop_monitor(
+    threshold_ms: float = 100.0,
+    warning_callback=None,
+):
+    global _original_handle_run, _warning_callback
+    _original_handle_run = asyncio.events.Handle._run
+    _warning_callback = warning_callback
+
+    def patched_run(self):
+        start = time.perf_counter()
+        try:
+            _original_handle_run(self)
+        finally:
+            elapsed_ms = (time.perf_counter() - start) * 1000
+            if elapsed_ms > threshold_ms:
+                cb_name = getattr(self._callback, "__qualname__", str(self._callback))
+                if _warning_callback:
+                    _warning_callback(
+                        f"Event loop blocked for {elapsed_ms:.1f}ms",
+                        elapsed_ms=elapsed_ms,
+                        threshold_ms=threshold_ms,
+                        handle_callback=cb_name,
+                    )
+                else:
+                    logger.warning(
+                        "Event loop blocked for %.1fms by %s", elapsed_ms, cb_name
+                    )
+
+    asyncio.events.Handle._run = patched_run
+
+def uninstall_eventloop_monitor():
+    global _original_handle_run, _warning_callback
+    if _original_handle_run is not None:
+        asyncio.events.Handle._run = _original_handle_run
+        _original_handle_run = None
+        _warning_callback = None

--- a/tests/test_eventloop.py
+++ b/tests/test_eventloop.py
@@ -1,0 +1,132 @@
+"""Tests for event loop blocking monitor."""
+from __future__ import annotations
+
+import asyncio
+import time
+
+import pytest
+
+from avatar_otel.instrumentation.eventloop import (
+    install_eventloop_monitor,
+    uninstall_eventloop_monitor,
+)
+
+
+def test_patch_applied_and_removed():
+    """Test that the patch is applied and removed correctly."""
+    import asyncio.events
+
+    original_run = asyncio.events.Handle._run
+
+    install_eventloop_monitor(threshold_ms=100.0)
+
+    patched_run = asyncio.events.Handle._run
+    assert patched_run is not original_run, "Patch was not applied"
+
+    uninstall_eventloop_monitor()
+
+    restored_run = asyncio.events.Handle._run
+    assert restored_run is original_run, "Original was not restored after uninstall"
+
+
+def test_blocking_handle_triggers_callback():
+    """Test that a blocking handle triggers the warning callback."""
+    warnings = []
+
+    def my_callback(msg, **kwargs):
+        warnings.append({"msg": msg, **kwargs})
+
+    install_eventloop_monitor(threshold_ms=50.0, warning_callback=my_callback)
+
+    try:
+        loop = asyncio.new_event_loop()
+
+        async def blocking_coro():
+            time.sleep(0.15)  # 150ms > 50ms threshold
+
+        loop.run_until_complete(blocking_coro())
+        loop.close()
+    finally:
+        uninstall_eventloop_monitor()
+
+    assert len(warnings) >= 1, "Warning callback was not called for blocking handle"
+    assert warnings[0]["elapsed_ms"] > 50.0
+    assert warnings[0]["threshold_ms"] == 50.0
+    assert "Event loop blocked" in warnings[0]["msg"]
+
+
+def test_fast_handle_does_not_trigger_callback():
+    """Test that a fast handle does NOT trigger the warning callback."""
+    warnings = []
+
+    def my_callback(msg, **kwargs):
+        warnings.append({"msg": msg, **kwargs})
+
+    install_eventloop_monitor(threshold_ms=200.0, warning_callback=my_callback)
+
+    try:
+        loop = asyncio.new_event_loop()
+
+        async def fast_coro():
+            await asyncio.sleep(0)  # yields control, very fast
+
+        loop.run_until_complete(fast_coro())
+        loop.close()
+    finally:
+        uninstall_eventloop_monitor()
+
+    assert len(warnings) == 0, f"Warning callback was unexpectedly called: {warnings}"
+
+
+def test_uninstall_restores_original_behavior():
+    """Test that uninstall restores original behavior (no more monitoring)."""
+    import asyncio.events
+
+    original_run = asyncio.events.Handle._run
+
+    install_eventloop_monitor(threshold_ms=10.0)
+    uninstall_eventloop_monitor()
+
+    assert asyncio.events.Handle._run is original_run
+
+    # Confirm no side effects after uninstall even if a blocking call is made
+    loop = asyncio.new_event_loop()
+
+    async def blocking_coro():
+        time.sleep(0.05)
+
+    loop.run_until_complete(blocking_coro())
+    loop.close()
+
+    # Still restored
+    assert asyncio.events.Handle._run is original_run
+
+
+def test_uninstall_is_idempotent():
+    """Test that calling uninstall multiple times is safe."""
+    install_eventloop_monitor(threshold_ms=100.0)
+    uninstall_eventloop_monitor()
+    uninstall_eventloop_monitor()  # should not raise
+
+
+def test_default_logger_warning(caplog):
+    """Test that the default logger is used when no callback is provided."""
+    import logging
+
+    install_eventloop_monitor(threshold_ms=50.0, warning_callback=None)
+
+    try:
+        with caplog.at_level(logging.WARNING, logger="avatar_otel.eventloop"):
+            loop = asyncio.new_event_loop()
+
+            async def blocking_coro():
+                time.sleep(0.15)
+
+            loop.run_until_complete(blocking_coro())
+            loop.close()
+    finally:
+        uninstall_eventloop_monitor()
+
+    assert any("Event loop blocked" in r.message for r in caplog.records), (
+        "Expected warning log not found"
+    )


### PR DESCRIPTION
## Summary

- Adds `src/avatar_otel/instrumentation/eventloop.py` which patches `asyncio.events.Handle._run` to detect event loop blocking callbacks
- Configurable threshold in milliseconds; supports a custom warning callback or falls back to the standard logger
- Adds `tests/test_eventloop.py` with 6 tests covering patch apply/remove, blocking trigger, fast no-trigger, idempotent uninstall, and default logger warning

## Test plan

- [x] `test_patch_applied_and_removed` — verifies patching and restoration of `Handle._run`
- [x] `test_blocking_handle_triggers_callback` — 150ms sleep exceeds 50ms threshold; callback fires
- [x] `test_fast_handle_does_not_trigger_callback` — fast coroutine does not trigger callback
- [x] `test_uninstall_restores_original_behavior` — after uninstall, original method is restored
- [x] `test_uninstall_is_idempotent` — double-uninstall does not raise
- [x] `test_default_logger_warning` — no callback provided; warning emitted via logger

All tests pass with 100% coverage on the new module.

Generated with [Claude Code](https://claude.com/claude-code)