### PR TITLE
Phase 6+12: PII scrubber, exporters, and init() orchestration

### DIFF
--- a/src/avatar_otel/__init__.py
+++ b/src/avatar_otel/__init__.py
@@ -1,5 +1,242 @@
-"""avatar-otel: OpenTelemetry observability for real-time AI avatar and video pipelines."""
+"""avatar-otel: OpenTelemetry observability for real-time AI avatar and video pipelines.
+
+Everything a user needs is importable from `avatar_otel` directly:
+
+    import avatar_otel
+
+    sdk = avatar_otel.init(service_name="artalk-avatar")
+
+    @avatar_otel.pipeline_stage("flame_inference")
+    async def run_model(...): ...
+
+    async with avatar_otel.stage("render") as s:
+        s.record("vertex_count", 12345)
+
+    avatar_otel.info("Pipeline started", target_fps=30)
+"""
+
+from __future__ import annotations
+
+from typing import Any
 
 from avatar_otel._version import __version__
+from avatar_otel.logging.api import (
+    debug,
+    error,
+    exception,
+    info,
+    notice,
+    trace_log as trace,
+    warning,
+)
+from avatar_otel.tracing.pipeline import async_stage, pipeline_stage, stage
 
-__all__ = ["__version__"]
+__all__ = [
+    "__version__",
+    "init",
+    "pipeline_stage",
+    "stage",
+    "async_stage",
+    "trace",
+    "debug",
+    "info",
+    "notice",
+    "warning",
+    "error",
+    "exception",
+]
+
+
+class RTVideoOtelSDK:
+    """SDK handle returned by init(). Context-manager compatible."""
+
+    def __init__(
+        self,
+        config,
+        tracer_provider,
+        meter_provider,
+        logger_provider,
+        frame_aggregator,
+        av_tracker,
+        gpu_monitor=None,
+        pending_processor=None,
+    ):
+        self._config = config
+        self._tracer_provider = tracer_provider
+        self._meter_provider = meter_provider
+        self._logger_provider = logger_provider
+        self.frame_aggregator = frame_aggregator
+        self.av_tracker = av_tracker
+        self._gpu_monitor = gpu_monitor
+        self._pending_processor = pending_processor
+        self._stopped = False
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        self.stop()
+
+    def flush(self) -> None:
+        """Force-flush all exporters."""
+        self._tracer_provider.force_flush()
+        self._meter_provider.force_flush()
+
+    def stop(self) -> None:
+        """Flush and shut down all components."""
+        if self._stopped:
+            return
+        self._stopped = True
+
+        self.frame_aggregator.stop()
+
+        if self._pending_processor is not None:
+            self._pending_processor.stop()
+
+        if self._gpu_monitor is not None:
+            self._gpu_monitor.stop()
+
+        from avatar_otel.instrumentation.eventloop import uninstall_eventloop_monitor
+        from avatar_otel.instrumentation.pytorch import uninstrument_pytorch
+        from avatar_otel.tracing.propagation import unpatch_all
+
+        uninstrument_pytorch()
+        unpatch_all()
+        uninstall_eventloop_monitor()
+
+        self._tracer_provider.shutdown()
+        self._meter_provider.shutdown()
+        self._logger_provider.shutdown()
+
+
+def init(**kwargs: Any) -> RTVideoOtelSDK:
+    """Initialize avatar-otel. One-liner to get full observability.
+
+    All kwargs are passed to AvatarOtelConfig (Pydantic Settings), which also
+    reads from AVATAR_OTEL_* environment variables and .env files.
+
+    Returns an RTVideoOtelSDK handle with .frame_aggregator, .av_tracker,
+    .flush(), and .stop() methods. Also works as a context manager.
+    """
+    from avatar_otel import _registry
+    from avatar_otel.config import AvatarOtelConfig
+    from avatar_otel.exporters.setup import (
+        create_resource,
+        setup_logger_provider,
+        setup_meter_provider,
+        setup_tracer_provider,
+    )
+    from avatar_otel.instrumentation.eventloop import install_eventloop_monitor
+    from avatar_otel.instrumentation.gpu import GPUMonitor
+    from avatar_otel.instrumentation.pytorch import instrument_pytorch
+    from avatar_otel.logging.api import _init_logging
+    from avatar_otel.logging.scrubber import ScrubbingSpanProcessor
+    from avatar_otel.metrics.aggregator import FrameMetricsAggregator
+    from avatar_otel.metrics.av_sync import AVSyncTracker
+    from avatar_otel.metrics.instruments import MetricInstruments
+    from avatar_otel.tracing.pending import PendingSpanProcessor
+    from avatar_otel.tracing.propagation import patch_all
+    from avatar_otel.tracing.sampler import AdaptiveSampler
+
+    config = AvatarOtelConfig(**kwargs)
+    _registry._config = config
+
+    resource = create_resource(config)
+    tracer_provider = setup_tracer_provider(config, resource)
+    meter_provider = setup_meter_provider(config, resource)
+    logger_provider = setup_logger_provider(config, resource)
+
+    tracer = tracer_provider.get_tracer("avatar-otel", __version__)
+    meter = meter_provider.get_meter("avatar-otel", __version__)
+    _registry._tracer = tracer
+    _registry._meter = meter
+
+    instruments = MetricInstruments(meter)
+
+    if config.scrubbing_enabled:
+        scrubber = ScrubbingSpanProcessor(
+            extra_patterns=config.scrubbing_patterns,
+            callback=config.scrubbing_callback,
+        )
+        tracer_provider.add_span_processor(scrubber)
+
+    from avatar_otel.exporters.setup import _create_span_exporter
+
+    pending_exporter = _create_span_exporter(config)
+    pending_processor = PendingSpanProcessor(
+        exporter=pending_exporter,
+        flush_interval_ms=config.pending_span_flush_interval_ms,
+    )
+    tracer_provider.add_span_processor(pending_processor)
+    pending_processor.start()
+
+    aggregator = FrameMetricsAggregator(
+        instruments=instruments,
+        buffer_size=config.ring_buffer_size,
+        flush_interval_ms=config.metrics_flush_interval_ms,
+    )
+    aggregator.start()
+
+    av_tracker = AVSyncTracker(
+        instruments=instruments,
+        drift_warning_ms=config.av_drift_warning_ms,
+        chunk_ttl_s=config.av_chunk_ttl_s,
+        jitter_window=config.av_jitter_window,
+        warning_callback=warning,
+    )
+
+    sampler = AdaptiveSampler(
+        window_s=config.span_window_s,
+        anomaly_threshold_ms=config.anomaly_threshold_ms,
+    )
+    _registry._sampler = sampler
+
+    gpu_monitor = None
+    if config.gpu_monitoring:
+        gpu_monitor = GPUMonitor(
+            poll_interval_s=config.gpu_poll_interval_s,
+            device_indices=config.gpu_device_indices,
+        )
+        if gpu_monitor.start():
+            gpu_monitor.register_gauges(meter)
+        else:
+            gpu_monitor = None
+
+    if config.pytorch_instrumentation:
+        instrument_pytorch(
+            tracer=tracer,
+            sample_rate=config.pytorch_sample_rate,
+            anomaly_threshold_ms=config.anomaly_threshold_ms,
+            track_memory=config.pytorch_track_memory,
+            track_shapes=config.pytorch_track_shapes,
+            aggregator=aggregator,
+        )
+
+    if config.threadpool_propagation:
+        patch_all()
+
+    if config.eventloop_monitoring:
+        install_eventloop_monitor(
+            threshold_ms=config.eventloop_lag_threshold_ms,
+            warning_callback=warning,
+        )
+
+    _init_logging(
+        logger_provider=logger_provider,
+        log_level=config.log_level,
+        log_console=config.log_console,
+    )
+
+    sdk = RTVideoOtelSDK(
+        config=config,
+        tracer_provider=tracer_provider,
+        meter_provider=meter_provider,
+        logger_provider=logger_provider,
+        frame_aggregator=aggregator,
+        av_tracker=av_tracker,
+        gpu_monitor=gpu_monitor,
+        pending_processor=pending_processor,
+    )
+    _registry._sdk = sdk
+
+    return sdk

--- a/src/avatar_otel/exporters/setup.py
+++ b/src/avatar_otel/exporters/setup.py
@@ -1,0 +1,126 @@
+"""OTLP exporter and provider setup.
+
+Configures TracerProvider, MeterProvider, and LoggerProvider with OTLP
+HTTP or gRPC exporters based on AvatarOtelConfig.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from opentelemetry import trace
+from opentelemetry.sdk.resources import Resource
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import BatchSpanProcessor
+
+if TYPE_CHECKING:
+    from avatar_otel.config import AvatarOtelConfig
+
+
+def create_resource(config: AvatarOtelConfig) -> Resource:
+    return Resource.create(
+        {
+            "service.name": config.service_name,
+            "service.version": config.service_version,
+            "deployment.environment": config.deployment_environment,
+        }
+    )
+
+
+def setup_tracer_provider(config: AvatarOtelConfig, resource: Resource) -> TracerProvider:
+    provider = TracerProvider(resource=resource)
+    exporter = _create_span_exporter(config)
+    provider.add_span_processor(BatchSpanProcessor(exporter))
+    trace.set_tracer_provider(provider)
+    return provider
+
+
+def setup_meter_provider(config: AvatarOtelConfig, resource: Resource):
+    from opentelemetry import metrics
+    from opentelemetry.sdk.metrics import MeterProvider
+    from opentelemetry.sdk.metrics.export import PeriodicExportingMetricReader
+
+    exporter = _create_metric_exporter(config)
+    reader = PeriodicExportingMetricReader(
+        exporter,
+        export_interval_millis=config.metrics_flush_interval_ms,
+    )
+    provider = MeterProvider(resource=resource, metric_readers=[reader])
+    metrics.set_meter_provider(provider)
+    return provider
+
+
+def setup_logger_provider(config: AvatarOtelConfig, resource: Resource):
+    from opentelemetry.sdk._logs import LoggerProvider
+    from opentelemetry.sdk._logs.export import BatchLogRecordProcessor
+
+    exporter = _create_log_exporter(config)
+    provider = LoggerProvider(resource=resource)
+    provider.add_log_record_processor(BatchLogRecordProcessor(exporter))
+    return provider
+
+
+def _create_span_exporter(config: AvatarOtelConfig):
+    endpoint = str(config.otlp_endpoint)
+    headers = config.otlp_headers
+    timeout = config.otlp_timeout_ms // 1000
+
+    if config.otlp_protocol == "grpc":
+        from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import OTLPSpanExporter
+
+        return OTLPSpanExporter(
+            endpoint=endpoint,
+            headers=tuple(headers.items()) if headers else None,
+            timeout=timeout,
+        )
+    from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
+
+    return OTLPSpanExporter(
+        endpoint=f"{endpoint}/v1/traces",
+        headers=headers,
+        timeout=timeout,
+    )
+
+
+def _create_metric_exporter(config: AvatarOtelConfig):
+    endpoint = str(config.otlp_endpoint)
+    headers = config.otlp_headers
+    timeout = config.otlp_timeout_ms // 1000
+
+    if config.otlp_protocol == "grpc":
+        from opentelemetry.exporter.otlp.proto.grpc.metric_exporter import OTLPMetricExporter
+
+        return OTLPMetricExporter(
+            endpoint=endpoint,
+            headers=tuple(headers.items()) if headers else None,
+            timeout=timeout,
+        )
+    from opentelemetry.exporter.otlp.proto.http.metric_exporter import OTLPMetricExporter
+
+    return OTLPMetricExporter(
+        endpoint=f"{endpoint}/v1/metrics",
+        headers=headers,
+        timeout=timeout,
+    )
+
+
+def _create_log_exporter(config: AvatarOtelConfig):
+    endpoint = str(config.otlp_endpoint)
+    headers = config.otlp_headers
+    timeout = config.otlp_timeout_ms // 1000
+
+    if config.otlp_protocol == "grpc":
+        from opentelemetry.exporter.otlp.proto.grpc._log_exporter import OTLPLogExporter
+
+        return OTLPLogExporter(
+            endpoint=endpoint,
+            headers=tuple(headers.items()) if headers else None,
+            timeout=timeout,
+        )
+    from opentelemetry.exporter.otlp.proto.http._log_exporter import OTLPLogExporter
+
+    return OTLPLogExporter(
+        endpoint=f"{endpoint}/v1/logs",
+        headers=headers,
+        timeout=timeout,
+    )

--- a/src/avatar_otel/logging/scrubber.py
+++ b/src/avatar_otel/logging/scrubber.py
@@ -1,0 +1,109 @@
+"""Scrubbing SpanProcessor for avatar-otel.
+
+Scans string-valued span attributes before export and redacts values matching
+sensitive patterns (passwords, tokens, secrets, API keys, credit card numbers,
+email addresses, phone numbers, etc.).
+
+Usage::
+
+    from avatar_otel.logging.scrubber import ScrubbingSpanProcessor
+
+    processor = ScrubbingSpanProcessor(
+        extra_patterns=[r"ssn", r"dob"],
+        callback=my_allow_list_fn,
+    )
+    tracer_provider.add_span_processor(processor)
+
+The optional *callback* receives ``(key, value, pattern)`` and should return
+``True`` to skip redaction for that attribute (i.e. allow-list it).
+"""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Callable
+
+from opentelemetry.sdk.trace import ReadableSpan, SpanProcessor
+
+# ---------------------------------------------------------------------------
+# Default sensitive patterns
+# ---------------------------------------------------------------------------
+
+DEFAULT_SCRUB_PATTERNS: list[str] = [
+    r"password",
+    r"token",
+    r"secret",
+    r"api[_-]?key",
+    r"authorization",
+    r"\b\d{4}[- ]?\d{4}[- ]?\d{4}[- ]?\d{4}\b",  # Credit card
+    r"\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Z|a-z]{2,}\b",  # Email
+    r"\b\d{3}[-.]?\d{3}[-.]?\d{4}\b",  # Phone number
+]
+
+
+# ---------------------------------------------------------------------------
+# ScrubbingSpanProcessor
+# ---------------------------------------------------------------------------
+
+
+class ScrubbingSpanProcessor(SpanProcessor):
+    """A SpanProcessor that redacts sensitive string-valued span attributes.
+
+    On ``on_end`` the processor iterates over all span attributes and
+    replaces the value of any string attribute whose *key* or *value* matches
+    a sensitive pattern with the literal string ``"[REDACTED]"``.
+
+    Parameters
+    ----------
+    extra_patterns:
+        Additional regex patterns (as strings) to add to the default set.
+        Each pattern is compiled case-insensitively.
+    callback:
+        Optional callable ``(key: str, value: str, pattern: re.Pattern) -> bool``.
+        When provided it is invoked for every attribute that would be redacted.
+        Returning ``True`` from the callback skips redaction for that attribute
+        (i.e. acts as an allow-list entry).
+    """
+
+    def __init__(
+        self,
+        extra_patterns: list[str] | None = None,
+        callback: Callable[[str, str, re.Pattern], bool] | None = None,
+    ) -> None:
+        patterns = DEFAULT_SCRUB_PATTERNS + (extra_patterns or [])
+        self._compiled_patterns: list[re.Pattern] = [
+            re.compile(p, re.IGNORECASE) for p in patterns
+        ]
+        self._callback = callback
+
+    # ------------------------------------------------------------------
+    # SpanProcessor interface
+    # ------------------------------------------------------------------
+
+    def on_start(self, span, parent_context=None) -> None:  # noqa: ANN001
+        """No-op — scrubbing is applied at export time (on_end)."""
+
+    def on_end(self, span: ReadableSpan) -> None:
+        """Redact sensitive attribute values before the span is exported."""
+        if not hasattr(span, "_attributes") or span._attributes is None:
+            return
+
+        for key, value in list(span._attributes.items()):
+            if not isinstance(value, str):
+                # Only string-valued attributes are scanned.
+                continue
+
+            for pattern in self._compiled_patterns:
+                if pattern.search(key) or pattern.search(value):
+                    # Give the caller a chance to allow-list this attribute.
+                    if self._callback is not None and self._callback(key, value, pattern):
+                        continue
+                    span._attributes[key] = "[REDACTED]"
+                    break
+
+    def shutdown(self) -> None:
+        """No-op — nothing to clean up."""
+
+    def force_flush(self, timeout_millis: int | None = None) -> bool:
+        """No-op — this processor is synchronous; always returns True."""
+        return True

--- a/tests/test_scrubber.py
+++ b/tests/test_scrubber.py
@@ -1,0 +1,296 @@
+"""Tests for ScrubbingSpanProcessor (logging/scrubber.py).
+
+Validates:
+1. Default patterns redact password, email, credit card, and phone number.
+2. Custom extra_patterns are applied in addition to the defaults.
+3. A callback can allow-list specific attributes (skip redaction).
+4. Non-string attributes are not touched.
+5. Attributes without sensitive content are preserved as-is.
+"""
+
+from __future__ import annotations
+
+import re
+from unittest.mock import MagicMock
+
+import pytest
+
+from avatar_otel.logging.scrubber import ScrubbingSpanProcessor
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_span(attributes: dict) -> MagicMock:
+    """Return a mock ReadableSpan with the given _attributes dict."""
+    span = MagicMock()
+    span._attributes = dict(attributes)
+    return span
+
+
+def _run_processor(attributes: dict, **kwargs) -> dict:
+    """Create a processor with kwargs, run on_end, and return the final attributes."""
+    processor = ScrubbingSpanProcessor(**kwargs)
+    span = _make_span(attributes)
+    processor.on_end(span)
+    return span._attributes
+
+
+# ---------------------------------------------------------------------------
+# 1. Default patterns
+# ---------------------------------------------------------------------------
+
+
+class TestDefaultPatterns:
+    def test_password_key_is_redacted(self):
+        result = _run_processor({"password": "s3cr3t!"})
+        assert result["password"] == "[REDACTED]"
+
+    def test_password_in_compound_key_is_redacted(self):
+        result = _run_processor({"user_password": "hunter2"})
+        assert result["user_password"] == "[REDACTED]"
+
+    def test_token_key_is_redacted(self):
+        result = _run_processor({"auth_token": "eyJhbGci..."})
+        assert result["auth_token"] == "[REDACTED]"
+
+    def test_secret_key_is_redacted(self):
+        result = _run_processor({"client_secret": "abc123"})
+        assert result["client_secret"] == "[REDACTED]"
+
+    def test_api_key_key_is_redacted(self):
+        result = _run_processor({"api_key": "sk-abcdef"})
+        assert result["api_key"] == "[REDACTED]"
+
+    def test_apikey_without_separator_is_redacted(self):
+        result = _run_processor({"apikey": "sk-abcdef"})
+        assert result["apikey"] == "[REDACTED]"
+
+    def test_authorization_key_is_redacted(self):
+        result = _run_processor({"authorization": "Bearer some-token"})
+        assert result["authorization"] == "[REDACTED]"
+
+    def test_email_value_is_redacted(self):
+        result = _run_processor({"user_contact": "alice@example.com"})
+        assert result["user_contact"] == "[REDACTED]"
+
+    def test_credit_card_value_is_redacted(self):
+        result = _run_processor({"card_info": "4111 1111 1111 1111"})
+        assert result["card_info"] == "[REDACTED]"
+
+    def test_credit_card_with_dashes_is_redacted(self):
+        result = _run_processor({"payment": "4111-1111-1111-1111"})
+        assert result["payment"] == "[REDACTED]"
+
+    def test_phone_number_value_is_redacted(self):
+        result = _run_processor({"phone": "555-867-5309"})
+        assert result["phone"] == "[REDACTED]"
+
+    def test_phone_with_dots_is_redacted(self):
+        result = _run_processor({"contact": "555.867.5309"})
+        assert result["contact"] == "[REDACTED]"
+
+    def test_sensitive_word_in_value_triggers_redaction(self):
+        """A value containing the word 'password' should also be redacted."""
+        result = _run_processor({"hint": "your password is here"})
+        assert result["hint"] == "[REDACTED]"
+
+
+# ---------------------------------------------------------------------------
+# 2. Custom extra patterns
+# ---------------------------------------------------------------------------
+
+
+class TestExtraPatterns:
+    def test_extra_pattern_redacts_matching_key(self):
+        result = _run_processor({"ssn": "123-45-6789"}, extra_patterns=[r"ssn"])
+        assert result["ssn"] == "[REDACTED]"
+
+    def test_extra_pattern_redacts_matching_value(self):
+        result = _run_processor(
+            {"identifier": "dob:1990-01-01"},
+            extra_patterns=[r"dob"],
+        )
+        assert result["identifier"] == "[REDACTED]"
+
+    def test_extra_pattern_does_not_affect_unrelated_attributes(self):
+        result = _run_processor(
+            {"frame_count": "42"},
+            extra_patterns=[r"ssn"],
+        )
+        assert result["frame_count"] == "42"
+
+    def test_extra_pattern_combined_with_default(self):
+        """Both the default and extra patterns should be active simultaneously."""
+        result = _run_processor(
+            {"password": "hunter2", "dob": "1990-01-01"},
+            extra_patterns=[r"dob"],
+        )
+        assert result["password"] == "[REDACTED]"
+        assert result["dob"] == "[REDACTED]"
+
+    def test_extra_pattern_is_case_insensitive(self):
+        result = _run_processor({"SSN": "123-45-6789"}, extra_patterns=[r"ssn"])
+        assert result["SSN"] == "[REDACTED]"
+
+
+# ---------------------------------------------------------------------------
+# 3. Callback allow-list
+# ---------------------------------------------------------------------------
+
+
+class TestCallbackAllowList:
+    def test_callback_returning_true_skips_redaction(self):
+        """A callback that returns True should prevent the attribute from being redacted."""
+
+        def allow_all(key, value, pattern):
+            return True  # Allow everything
+
+        result = _run_processor({"password": "s3cr3t!"}, callback=allow_all)
+        assert result["password"] == "s3cr3t!"
+
+    def test_callback_returning_false_allows_redaction(self):
+        """A callback that returns False should let redaction proceed normally."""
+
+        def deny_all(key, value, pattern):
+            return False  # Block nothing — allow redaction to proceed
+
+        result = _run_processor({"password": "s3cr3t!"}, callback=deny_all)
+        assert result["password"] == "[REDACTED]"
+
+    def test_callback_can_selectively_allow(self):
+        """Callback can allow-list specific keys while letting others be redacted."""
+
+        def allow_known_safe(key, value, pattern):
+            return key == "safe_token"  # Allow only this one
+
+        result = _run_processor(
+            {"safe_token": "public-value", "secret": "private"},
+            callback=allow_known_safe,
+        )
+        assert result["safe_token"] == "public-value"
+        assert result["secret"] == "[REDACTED]"
+
+    def test_callback_receives_correct_arguments(self):
+        """Callback must be called with (key, value, compiled_pattern)."""
+        received_calls: list[tuple] = []
+
+        def capturing_callback(key, value, pattern):
+            received_calls.append((key, value, pattern))
+            return False  # Allow redaction
+
+        _run_processor({"password": "secret123"}, callback=capturing_callback)
+
+        assert len(received_calls) == 1
+        key, value, pattern = received_calls[0]
+        assert key == "password"
+        assert value == "secret123"
+        assert isinstance(pattern, re.Pattern)
+
+    def test_no_callback_does_not_crash(self):
+        """When callback=None redaction proceeds without errors."""
+        result = _run_processor({"token": "abc"})
+        assert result["token"] == "[REDACTED]"
+
+
+# ---------------------------------------------------------------------------
+# 4. Non-string attributes are not touched
+# ---------------------------------------------------------------------------
+
+
+class TestNonStringAttributes:
+    def test_integer_attribute_not_touched(self):
+        result = _run_processor({"frame_count": 100})
+        assert result["frame_count"] == 100
+
+    def test_float_attribute_not_touched(self):
+        result = _run_processor({"duration_ms": 47.3})
+        assert result["duration_ms"] == pytest.approx(47.3)
+
+    def test_boolean_attribute_not_touched(self):
+        result = _run_processor({"is_keyframe": True})
+        assert result["is_keyframe"] is True
+
+    def test_none_attribute_not_touched(self):
+        result = _run_processor({"optional": None})
+        assert result["optional"] is None
+
+    def test_mixed_types_only_string_affected(self):
+        """Only the string attribute matching a pattern should be redacted."""
+        result = _run_processor(
+            {"frame_count": 42, "password": "secret", "drift_ms": 3.14}
+        )
+        assert result["frame_count"] == 42
+        assert result["password"] == "[REDACTED]"
+        assert result["drift_ms"] == pytest.approx(3.14)
+
+
+# ---------------------------------------------------------------------------
+# 5. Non-sensitive attributes are preserved
+# ---------------------------------------------------------------------------
+
+
+class TestNonSensitiveAttributesPreserved:
+    def test_safe_string_attribute_preserved(self):
+        result = _run_processor({"stage_name": "render"})
+        assert result["stage_name"] == "render"
+
+    def test_safe_numeric_string_preserved(self):
+        result = _run_processor({"frame_id": "1234"})
+        assert result["frame_id"] == "1234"
+
+    def test_safe_url_preserved(self):
+        result = _run_processor({"endpoint": "https://api.example.com/v1/health"})
+        assert result["endpoint"] == "https://api.example.com/v1/health"
+
+    def test_multiple_safe_attributes_all_preserved(self):
+        attrs = {
+            "pipeline_id": "pipe-001",
+            "stage_name": "encode",
+            "resolution": "1920x1080",
+            "target_fps": "30",
+        }
+        result = _run_processor(attrs)
+        for key, value in attrs.items():
+            assert result[key] == value
+
+    def test_empty_attributes_dict_no_error(self):
+        result = _run_processor({})
+        assert result == {}
+
+
+# ---------------------------------------------------------------------------
+# 6. Edge cases: span without _attributes
+# ---------------------------------------------------------------------------
+
+
+class TestEdgeCases:
+    def test_span_without_attributes_attr_does_not_crash(self):
+        """on_end should be a no-op when the span has no _attributes attribute."""
+        processor = ScrubbingSpanProcessor()
+        span = MagicMock(spec=[])  # spec=[] means no attributes at all
+        processor.on_end(span)  # Should not raise
+
+    def test_span_with_none_attributes_does_not_crash(self):
+        """on_end should be a no-op when _attributes is None."""
+        processor = ScrubbingSpanProcessor()
+        span = MagicMock()
+        span._attributes = None
+        processor.on_end(span)  # Should not raise
+
+    def test_shutdown_does_not_raise(self):
+        processor = ScrubbingSpanProcessor()
+        processor.shutdown()  # Should not raise
+
+    def test_force_flush_returns_true(self):
+        processor = ScrubbingSpanProcessor()
+        assert processor.force_flush() is True
+        assert processor.force_flush(timeout_millis=1000) is True
+
+    def test_on_start_does_not_raise(self):
+        processor = ScrubbingSpanProcessor()
+        span = MagicMock()
+        processor.on_start(span)  # Should not raise
+        processor.on_start(span, parent_context=MagicMock())  # Should not raise


### PR DESCRIPTION
## Summary
- `ScrubbingSpanProcessor` for PII pattern redaction (credit cards, emails, phones, tokens)
- `exporters/setup.py` for OTLP HTTP/gRPC provider configuration
- `init()` one-liner wiring up all 14 components in correct order
- `RTVideoOtelSDK` handle with context manager support for clean shutdown

## Test plan
- [x] 144/144 tests passing across all modules
- [x] init() smoke test with component creation and shutdown
- [x] Context manager lifecycle verified
- [x] Scrubber unit tests (default patterns, custom patterns, callback allow-list)

🤖 Generated with [Claude Code](https://claude.com/claude-code)